### PR TITLE
Add SystemHeat support

### DIFF
--- a/GameData/REPOSoftTech/DeepFreeze/Patches/DeepFreeze_SystemHeat.cfg
+++ b/GameData/REPOSoftTech/DeepFreeze/Patches/DeepFreeze_SystemHeat.cfg
@@ -1,0 +1,16 @@
+@PART[CRY-0300Freezer|CRY-0300RFreezer|CRY-1300Freezer|CRY-2300Freezer]:NEEDS[DeepFreeze,SystemHeat]
+{
+	MODULE
+	{
+		name = ModuleSystemHeat
+
+		// Thermal loop ID
+		systemHeatModuleID = cryoFreezeLoop
+
+		volume = #$../mass$
+		@volume *= 0.5
+
+		// UI
+		iconName = Icon_Snow
+	}
+}

--- a/Source/APIs/SystemHeatWrapper.cs
+++ b/Source/APIs/SystemHeatWrapper.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Debug = UnityEngine.Debug;
+
+namespace DF
+{
+    /// <summary>
+    /// The Wrapper class to access SystemHeat
+    /// </summary>
+    public class SystemHeatWrapper
+    {
+        protected static Type SHType;
+        protected static Object actualSH;
+
+        public static SHAPI SHActualAPI;
+
+        public static Boolean AssemblyExists { get { return SHType != null; } }
+
+        public static Boolean InstanceExists { get { return SHActualAPI != null; } }
+
+        private static Boolean _SHWrapped;
+
+        public static Boolean APIReady { get { return _SHWrapped; } }
+
+        public static Boolean InitSystemHeatWrapper()
+        {
+            _SHWrapped = false;
+            actualSH = null;
+            LogFormatted_DebugOnly("Attempting to Grab SystemHeat Types...");
+            LogFormatted("Attempting to Grab SystemHeat Types...");
+
+            SHType = getType("SystemHeat.ModuleSystemHeat");
+
+            if (SHType == null)
+            {
+                return false;
+            }
+
+            LogFormatted("SystemHeat Version:{0}", SHType.Assembly.GetName().Version.ToString());
+
+            LogFormatted_DebugOnly("Got Instance, Creating Wrapper Objects");
+            SHActualAPI = new SHAPI();
+
+            _SHWrapped = true;
+            return true;
+        }
+
+        internal static Type getType(string name)
+        {
+            Type type = null;
+            AssemblyLoader.loadedAssemblies.TypeOperation(t =>
+
+            {
+                if (t.FullName == name)
+                    type = t;
+            }
+            );
+
+            if (type != null)
+            {
+                return type;
+            }
+            return null;
+        }
+
+        public static void AddFlux(PartModule actualModule, string id, float sourceTemperature, float flux, bool useForNominal) {
+          SHActualAPI.AddFlux(actualModule, id, sourceTemperature, flux, useForNominal);
+        }
+
+        /// <summary>
+        /// The Type that is an analogue of the real SystemHeat. This lets you access all the API-able properties and Methods of SystemHeat
+        public class SHAPI
+        {
+            internal SHAPI()
+            {
+                LogFormatted_DebugOnly("Getting hook_AddFlux Method");
+                SHhook_AddFluxMethod = SHType.GetMethod("AddFlux", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+                LogFormatted_DebugOnly("Success: " + (SHhook_AddFluxMethod != null));
+            }
+
+            #region Methods
+
+            private MethodInfo SHhook_AddFluxMethod;
+
+            /// <summary>
+            /// Add heat flux at a given temperature to system (in SystemHeat)
+            /// </summary>
+            /// <param name="id">the string ID of the source (should be unique)</param>
+            /// <param name="sourceTemperature">the temperature of the source</param>
+            /// <param name="flux">the flux of the source</param>
+            /// <param name="useForNominal">
+            ///   whether this temperature should be used when determining the nominal temperature
+            ///   of the loop
+            /// </param>
+            /// public void AddFlux(string id, float sourceTemperature, float flux, bool useForNominal)
+            internal void AddFlux(PartModule actualModule, string id, float sourceTemperature, float flux, bool useForNominal)
+            {
+                try
+                {
+                    SHhook_AddFluxMethod.Invoke(actualModule, new System.Object[] { id, sourceTemperature, flux, useForNominal });
+                }
+                catch (Exception ex)
+                {
+                    LogFormatted("Unable to invoke SystemHeat AddFlux Method");
+                    LogFormatted("Exception: {0}", ex);
+                    //throw;
+                }
+            }
+            #endregion Methods
+        }
+
+
+        #region Logging Stuff
+
+        /// <summary>
+        /// Some Structured logging to the debug file - ONLY RUNS WHEN DLL COMPILED IN DEBUG MODE
+        /// </summary>
+        /// <param name="Message">Text to be printed - can be formatted as per String.format</param>
+        /// <param name="strParams">Objects to feed into a String.format</param>
+        internal static void LogFormatted_DebugOnly(String Message, params Object[] strParams)
+        {
+            if (RSTUtils.Utilities.debuggingOn)
+                LogFormatted(Message, strParams);
+        }
+
+        /// <summary>
+        /// Some Structured logging to the debug file
+        /// </summary>
+        /// <param name="Message">Text to be printed - can be formatted as per String.format</param>
+        /// <param name="strParams">Objects to feed into a String.format</param>
+        internal static void LogFormatted(String Message, params Object[] strParams)
+        {
+            Message = String.Format(Message, strParams);
+            String strMessageLine = String.Format("{0},{2}-{3},{1}",
+                DateTime.Now, Message, Assembly.GetExecutingAssembly().GetName().Name,
+                MethodBase.GetCurrentMethod().DeclaringType.Name);
+            Debug.Log(strMessageLine);
+        }
+
+        #endregion Logging Stuff
+    }
+}

--- a/Source/DFInstalledMods.cs
+++ b/Source/DFInstalledMods.cs
@@ -140,6 +140,14 @@ namespace DF
             }
         }
 
+        internal static bool IsSystemHeatInstalled
+        {
+            get
+            {
+                return IsModInstalled("SystemHeat");
+            }
+        }
+
         internal static bool IsModInstalled(string assemblyName)
         {
             ModInfo info = GetInfo(assemblyName);

--- a/Source/DFIntMemory.cs
+++ b/Source/DFIntMemory.cs
@@ -185,6 +185,10 @@ namespace DF
                 {
                     SMWrapper.InitSMWrapper();
                 }
+                if (DFInstalledMods.IsSystemHeatInstalled)
+                {
+                    SystemHeatWrapper.InitSystemHeatWrapper();
+                }
             }
             if (DFInstalledMods.IsRTInstalled)
             {

--- a/Source/DeepFreeze.csproj
+++ b/Source/DeepFreeze.csproj
@@ -90,6 +90,7 @@
     <Compile Include="APIs\SMWrapper.cs" />
     <Compile Include="APIs\TRWrapper.cs" />
     <Compile Include="APIs\USIWrapper.cs" />
+    <Compile Include="APIs\SystemHeatWrapper.cs" />
     <Compile Include="SettingsParms.cs" />
     <Compile Include="Textures.cs" />
     <Compile Include="VesselInfo.cs" />

--- a/Source/DeepFreezerPart.cs
+++ b/Source/DeepFreezerPart.cs
@@ -643,12 +643,12 @@ namespace DF
                     if (DeepFreeze.Instance.DFsettings.TempinKelvin)
                     {
                         Fields["CabinTemp"].guiUnits = Localizer.Format("#autoLOC_DF_00061"); //#autoLOC_DF_00061 = K
-                        CabinTemp = (float)part.temperature;
+                        CabinTemp = (float)GetSystemTemp();
                     }
                     else
                     {
                         Fields["CabinTemp"].guiUnits = Localizer.Format("#autoLOC_DF_00070"); //#autoLOC_DF_00070 = C
-                        CabinTemp = RSTUtils.Utilities.KelvintoCelsius((float)part.temperature);
+                        CabinTemp = RSTUtils.Utilities.KelvintoCelsius((float)GetSystemTemp());
                     }
 
                     // If RemoteTech installed set the connection status
@@ -1382,6 +1382,33 @@ namespace DF
             //RSTUtils.Utilities.Log_Debug("ChkOngoingEC end");
         }
 
+        private double GetSystemTemp() {
+            if (DFInstalledMods.IsSystemHeatInstalled) {
+              var shModule = part.Modules["ModuleSystemHeat"];
+              var foo = shModule.Fields["currentLoopTemperature"];
+              return (float)foo.GetValue(shModule);
+            } else {
+              return part.temperature;
+            }
+        }
+
+        private void AddThermalFlux(double heatamt) {
+            if (DFInstalledMods.IsSystemHeatInstalled) {
+                PartModule targetModule = part.Modules["ModuleSystemHeat"];
+                SystemHeatWrapper.AddFlux(targetModule, "DeepFreezeLoopSystemHeat", 30, (float)heatamtMonitoringFrznKerbals * TotalFrozen, true);
+            } else {
+                part.AddThermalFlux(heatamt);
+            }
+        }
+
+        private void UpdateHeatFlux() {
+          if (DFInstalledMods.IsSystemHeatInstalled) {
+              PartModule targetModule = part.Modules["ModuleSystemHeat"];
+              int isOneFrozen = (TotalFrozen > 0) ? 1 : 0;
+              SystemHeatWrapper.AddFlux(targetModule, "DeepFreezeLoopSystemHeat", 30*isOneFrozen, (float)heatamtMonitoringFrznKerbals * TotalFrozen, true);
+          }
+        }
+
         private void ChkOngoingTemp(PartInfo partInfo)
         {
             // The follow section of code checks Temperatures when we have RegTempReqd set to true in the master config file.
@@ -1398,16 +1425,16 @@ namespace DF
                 {
                     //Add Heat for equipment monitoring frozen kerbals
                     double heatamt = heatamtMonitoringFrznKerbals / 60.0f * timeperiod * TotalFrozen;
-                    if (heatamt > 0) part.AddThermalFlux(heatamt);
+                    if (heatamt > 0) AddThermalFlux(heatamt);
                     RSTUtils.Utilities.Log_Debug("Added " + heatamt + " kW of heat for monitoring " + TotalFrozen + " frozen kerbals");
-                    if (part.temperature < DeepFreeze.Instance.DFsettings.RegTempMonitor)
+                    if (GetSystemTemp() < DeepFreeze.Instance.DFsettings.RegTempMonitor)
                     {
-                        RSTUtils.Utilities.Log_Debug("DeepFreezer Temperature check is good parttemp=" + part.temperature + ",MaxTemp=" + DeepFreeze.Instance.DFsettings.RegTempMonitor);
+                        RSTUtils.Utilities.Log_Debug("DeepFreezer Temperature check is good parttemp=" + GetSystemTemp() + ",MaxTemp=" + DeepFreeze.Instance.DFsettings.RegTempMonitor);
                         if (TempChkMsg != null) ScreenMessages.RemoveMessage(TempChkMsg);
                         _FrzrTmp = FrzrTmpStatus.OK;
                         tmpdeathCounter = currenttime;
                         // do warning if within 40 and 20 kelvin
-                        double tempdiff = DeepFreeze.Instance.DFsettings.RegTempMonitor - part.temperature;
+                        double tempdiff = DeepFreeze.Instance.DFsettings.RegTempMonitor - GetSystemTemp();
                         if (tempdiff <= 40)
                         {
                             _FrzrTmp = FrzrTmpStatus.WARN;
@@ -1427,7 +1454,7 @@ namespace DF
                     else
                     {
                         // OVER TEMP I'm Melting!!!!
-                        Debug.Log("DeepFreezer Part Temp TOO HOT, Kerbals are going to melt parttemp=" + part.temperature);
+                        Debug.Log("DeepFreezer Part Temp TOO HOT, Kerbals are going to melt parttemp=" + GetSystemTemp());
                         if (!partInfo.TempWarning)
                         {
                             if (TimeWarp.CurrentRateIndex > 1) RSTUtils.Utilities.stopWarp();
@@ -2030,7 +2057,7 @@ namespace DF
                         FreezeMsg = ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_DF_00082", StoredCharge.ToString("######0"))); //#autoLOC_DF_00082 = \u0020Cryopod - Charging: <<1>>
                         if (DeepFreeze.Instance.DFsettings.RegTempReqd)
                         {
-                            part.AddThermalFlux(heatamtThawFreezeKerbal);
+                            AddThermalFlux(heatamtThawFreezeKerbal);
                         }
                         RSTUtils.Utilities.Log_Debug("DeepFreezer Drawing Charge StoredCharge =" + StoredCharge.ToString("0000.00") + " ChargeRequired =" + ChargeRequired);
                         if (StoredCharge >= ChargeRequired)
@@ -2245,9 +2272,9 @@ namespace DF
                     {
                         if (DeepFreeze.Instance.DFsettings.RegTempReqd) // Temperature check is required
                         {
-                            if ((float)part.temperature > DeepFreeze.Instance.DFsettings.RegTempFreeze)
+                            if ((float)GetSystemTemp() > DeepFreeze.Instance.DFsettings.RegTempFreeze)
                             {
-                                ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_DF_00084", (DeepFreeze.Instance.DFsettings.TempinKelvin ? DeepFreeze.Instance.DFsettings.RegTempFreeze.ToString("######0") : (DeepFreeze.Instance.DFsettings.RegTempFreeze - 273.15d).ToString("######0")) + Fields["CabinTemp"].guiUnits), 5.0f, ScreenMessageStyle.UPPER_CENTER); //#autoLOC_DF_00084 = Cannot Freeze while Temperature greater than <<1>> 
+                                ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_DF_00084", (DeepFreeze.Instance.DFsettings.TempinKelvin ? DeepFreeze.Instance.DFsettings.RegTempFreeze.ToString("######0") : (DeepFreeze.Instance.DFsettings.RegTempFreeze - 273.15d).ToString("######0")) + Fields["CabinTemp"].guiUnits), 5.0f, ScreenMessageStyle.UPPER_CENTER); //#autoLOC_DF_00084 = Cannot Freeze while Temperature greater than <<1>>
                                 return;
                             }
                         }
@@ -2584,7 +2611,7 @@ namespace DF
 
                         if (DeepFreeze.Instance.DFsettings.RegTempReqd)
                         {
-                            part.AddThermalFlux(heatamtThawFreezeKerbal);
+                            AddThermalFlux(heatamtThawFreezeKerbal);
                         }
                         if (StoredCharge >= ChargeRequired)
                         {


### PR DESCRIPTION
Adds support to use the new replacement heat system introduced by the SystemHeat mod: 
https://github.com/KSPModStewards/SystemHeat

I thought it could be cool, if the Freezer Pods could be cooled this way. 

So far, this is just the bare minimum to get it to work at all. I will try to integrate it a bit more, just wanted to get it out there today, just in case I lose interest or hit the limits of what I can do (new to this side of KSP modding).

Have some Ideas that may be interesting gameplay, such as having to cool the Glykerol as well or being able to freeze Kerbals cheaper with adequate cooling (which in-itself could be another challenge).

And finally: Thank you for adopting and maintaining all those mods!